### PR TITLE
simplify join to oneline reduce

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,7 @@
 "use strict";
 
-function join(output, separator = ",") {
-  let str = "";
-  if (output.length !== 0) {
-    const lastIndex = output.length - 1;
-    for (let i = 0; i < lastIndex; i++) {
-      // It is faster not to use a template string here
-      str += output[i];
-      str += separator;
-    }
-    str += output[lastIndex];
-  }
-  return str;
-}
+const join = (output, separator = ",") =>
+  output.reduce((result, chunk) => result + separator + chunk, "");
 
 module.exports = join;
 module.exports.default = join;


### PR DESCRIPTION
Looks like it can be simplified to oneline reduce

```
╔══════════════════════╤═════════╤════════════════════╤═══════════╗
║ Slower tests         │ Samples │             Result │ Tolerance ║
╟──────────────────────┼─────────┼────────────────────┼───────────╢
║ Array.prototype.join │   10000 │ 11997802.00 op/sec │ ± 16.85 % ║
╟──────────────────────┼─────────┼────────────────────┼───────────╢
║ Fastest test         │ Samples │             Result │ Tolerance ║
╟──────────────────────┼─────────┼────────────────────┼───────────╢
║ fast-array-join      │   10000 │ 14235037.55 op/sec │ ±  8.72 % ║
╚══════════════════════╧═════════╧════════════════════╧═══════════╝

╔══════════════════════╤═════════╤════════════════════╤═══════════╗
║ Slower tests         │ Samples │             Result │ Tolerance ║
╟──────────────────────┼─────────┼────────────────────┼───────────╢
║ Array.prototype.join │   10000 │ 11310042.19 op/sec │  ± 8.04 % ║
╟──────────────────────┼─────────┼────────────────────┼───────────╢
║ Fastest test         │ Samples │             Result │ Tolerance ║
╟──────────────────────┼─────────┼────────────────────┼───────────╢
║ fast-array-join      │   10000 │ 12909139.02 op/sec │  ± 7.85 % ║
╚══════════════════════╧═════════╧════════════════════╧═══════════╝

╔══════════════════════╤═════════╤═══════════════════╤═══════════╗
║ Slower tests         │ Samples │            Result │ Tolerance ║
╟──────────────────────┼─────────┼───────────────────┼───────────╢
║ Array.prototype.join │   10000 │ 7704973.48 op/sec │ ± 11.52 % ║
╟──────────────────────┼─────────┼───────────────────┼───────────╢
║ Fastest test         │ Samples │            Result │ Tolerance ║
╟──────────────────────┼─────────┼───────────────────┼───────────╢
║ fast-array-join      │   10000 │ 7946845.14 op/sec │ ± 13.36 % ║
╚══════════════════════╧═════════╧═══════════════════╧═══════════╝

╔══════════════════════╤═════════╤══════════════════╤═══════════╗
║ Slower tests         │ Samples │           Result │ Tolerance ║
╟──────────────────────┼─────────┼──────────────────┼───────────╢
║ Array.prototype.join │    7000 │ 116801.47 op/sec │  ± 1.00 % ║
╟──────────────────────┼─────────┼──────────────────┼───────────╢
║ Fastest test         │ Samples │           Result │ Tolerance ║
╟──────────────────────┼─────────┼──────────────────┼───────────╢
║ fast-array-join      │   10000 │ 193332.14 op/sec │  ± 1.78 % ║
╚══════════════════════╧═════════╧══════════════════╧═══════════╝
```